### PR TITLE
Update dumpster to latest

### DIFF
--- a/Dumpster.lua
+++ b/Dumpster.lua
@@ -38,6 +38,8 @@ local Dumpster = {} do
 		end
 		table.clear(self)
 	end
+
+	Dumpster.destroy = Dumpster.burn
 end
 
 return Dumpster


### PR DESCRIPTION
What changed:
- Updated dumpster to the [latest version](https://gist.github.com/Fraktality/f0ab4ad950698e9f08bb01bea486845e)
- `Dumpster:dump` no longer returns self, it returns the item/function/connection that was passed
- Returns dumpster itself rather than indexed in a table
- Kept table method and destroy alias